### PR TITLE
fix: cds.persistence.skip

### DIFF
--- a/index.cds
+++ b/index.cds
@@ -1,6 +1,7 @@
 namespace sap.print;
 
-@cds.skip.peristance
+
+@cds.persistence.skip
 entity Queues {
     key ID          : String;
         description : String;


### PR DESCRIPTION
- depending on how the Queue should be used we could remove this annotation, so it is only accesible when there is a projection. This can be done when the queue is not saved in the data model of the main entity anymore