### PR TITLE
using services from cds-plugin.js

### DIFF
--- a/cds-plugin.js
+++ b/cds-plugin.js
@@ -44,8 +44,19 @@ cds.once("served", async () => {
                         // Track the action parameters holding print configurations
                         await getAnnotatedParamsOfAction(boundAction);
                         const sourceentity = getQueueValueHelpEntity(boundAction.params);
+                        const printer = await cds.connect.to("print");
                         if(sourceentity && !queueValueHelpHandlerRegistered) {
-                            srv.after('READ', sourceentity, populateQueueValueHelp);
+                            srv.after('READ', sourceentity, async (_, req) => {
+                                // TODO: make sure the format of all services are the same
+                                const q = await printer.getQueues();
+
+                                q.forEach((item, index) => {
+                                    req.results[index] = { ID: item.ID };
+                                });
+                                req.results.$count = q.length;
+                                return;
+
+                            });
                         }
                         const actionName = boundAction.name.split('.').pop();
 


### PR DESCRIPTION
This PR shows how to use the defined print services (console and print service) in the `cds-plugin.js` to use the queries coming from the services that is used depending on the profile.

This sample can be used to update all the other requests in the `cds-plugin.js` to the services defined in the lib, slowly moving to detach the cds-plugin.js from the `lib/` and only use the services defined in `srv/`. Then, only the profiles from CAP and not the custom `PRINT_CONSOLE_MODE` should be used. The cds-plugin.js can connect to the right service via `cds.connect.to("print")` and the method needed can be called to get the data depending on the profile.

Tested with https://github.com/lisajulia/incidents/tree/use-print-plugin