### PR TITLE
fix: use buffer to send file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Draft enabled entities can be print enabled
 - Entities with composite keys can be print enabled
-- File upload during printing is now formatted correctly 
+- File upload during printing is now formatted correctly
 
 ## Version 0.1.0 - 2025-11-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 - Draft enabled entities can be print enabled
 - Entities with composite keys can be print enabled
+- File upload during printing is now formatted correctly 
 
 ## Version 0.1.0 - 2025-11-28
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cap-js/print",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "CAP plugin for SAP Cloud Print Service.",
   "repository": "cap-js/print",
   "homepage": "https://cap.cloud.sap/",

--- a/srv/BTPPrintService.js
+++ b/srv/BTPPrintService.js
@@ -77,7 +77,7 @@ module.exports = class BTPPrintService extends PrintService {
           Authorization: `Bearer ${jwt}`,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(doc.content),
+        body: Buffer.from(doc.content, "base64"),
       });
       const responseData = await response.text();
       doc.objectKey = responseData;


### PR DESCRIPTION
Files were sent to Print Service before, but were wrongly formatted. It was not possible to download the file from the service to preview it because it was malformed.