### PR TITLE
chore: trigger pr on pull_request_target

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -47,12 +47,14 @@ runs:
           fi
         done
 
-    - uses: actions/checkout@v2
-
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+    - uses: actions/checkout@v5
       with:
-        node-version: ${{ matrix.node-version }}
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+    - name: Use Node.js ${{ inputs.NODE_VERSION }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.NODE_VERSION }}
 
     - name: Install global CDS
       shell: bash

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,18 @@
+name: Check Changelog
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  Check-Changelog:
+    name: Check Changelog Action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tarides/changelog-check-action@v3
+        with:
+          changelog: CHANGELOG.md

--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, auto_merge_enabled]
 
+permissions:
+  contents: read
+
 concurrency:
   group: lint-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v4
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: npm i
       - run: npm run lint
       - run: npm run prettier:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,26 @@ permissions:
   id-token: write
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x]
+        cds-version: [latest]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
+      - run: npm i
+      - run: npm run lint
+      - run: cd test/bookshop && npm i
+      - run: npm run test
   publish-npm:
+    needs: test
     runs-on: ubuntu-latest
     environment: npm
     steps:
@@ -17,15 +36,7 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
-
-      - name: Run Tests
-        run: |
-          npm install
-          npm run lint
-          cd test/bookshop && npm install
-          cd ../..
-          npm run test
-
+      - run: npm i
       - name: get-version
         id: package-version
         uses: martinbeentjes/npm-get-version-action@v1.2.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches: [main]
     types: [reopened, synchronize, opened]
 
+permissions:
+  contents: read
+
 jobs:
   requires-approval:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,14 @@ jobs:
   requires-approval:
     runs-on: ubuntu-latest
     name: "Waiting for PR approval as this workflow runs on pull_request_target"
-    if: github.event_name == 'pull_request_target' && github.event.pull_request.base.user.login != 'cap-js'
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.owner.login != 'cap-js'
     environment: pr-approval
     steps:
       - name: Approval Step
         run: echo "This job has been approved!"
   test:
+    needs: requires-approval
+    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 3
     strategy:
@@ -26,9 +28,11 @@ jobs:
         node-version: [20.x, 22.x]
         cds-version: [latest]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g @sap/cds-dk@${{ matrix.cds-version }}
@@ -36,6 +40,8 @@ jobs:
       - run: cd test/bookshop && npm i
       - run: npm run test
   integration-tests:
+    needs: requires-approval
+    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -44,7 +50,9 @@ jobs:
         cds-version: [latest]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Integration tests
         uses: ./.github/actions/integration-tests
         with:

--- a/test/bookshop/package.json
+++ b/test/bookshop/package.json
@@ -11,9 +11,6 @@
     "watch:hybrid": "cds watch --profile hybrid"
   },
   "private": true,
-  "devDependencies": {
-    "cds-launchpad-plugin": "^2.2.0"
-  },
   "sapux": [
     "app/browse",
     "app/admin-books",


### PR DESCRIPTION
# Fix CI Workflow to Properly Handle `pull_request_target` Events

### Chore

🔧 Updated CI workflow and integration test action to correctly handle `pull_request_target` events, ensuring PRs from external forks are checked out at the correct commit SHA and approval gating is applied consistently.

### Changes

* `.github/workflows/test.yml`:
  - Fixed the `requires-approval` condition to check `head.repo.owner.login` instead of `base.user.login` for proper fork detection.
  - Added `needs: requires-approval` and the corresponding `if` condition to both `test` and `integration-tests` jobs, ensuring they wait for approval when triggered from forks.
  - Upgraded `actions/checkout` from `v2`/`v4` to `v5` and `actions/setup-node` from `v2` to `v4`.
  - Added explicit `ref: ${{ github.event.pull_request.head.sha || github.sha }}` to checkout steps to ensure the PR head commit is used (important for `pull_request_target` security).

* `.github/actions/integration-tests/action.yml`:
  - Upgraded `actions/checkout` from `v2` to `v5` with the same explicit `ref` for the correct commit SHA.
  - Updated `actions/setup-node` from `v2` to `v4` and aligned node version input references to use `inputs.NODE_VERSION`.

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.18.11` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Event Trigger: `pull_request.opened`
- Correlation ID: `79bfa020-22e6-11f1-9efe-0023cd0d2de3`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- LLM: `anthropic--claude-4.6-sonnet`
</details>
