### PR TITLE
chore: dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -12,3 +14,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
# Add Dependabot Cooldown Configuration

### Chore

🔧 Added a cooldown period to the Dependabot configuration to reduce the frequency of dependency update pull requests.

### Changes

* `.github/dependabot.yml`: Added a `cooldown` setting with `default-days: 7` for both the `npm` and `github-actions` package ecosystems. This introduces a 7-day cooldown between dependency update PRs, helping to reduce noise from frequent automated updates.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.37`

- File Content Strategy: Full file content
- Event Trigger: `pull_request.opened`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- LLM: `anthropic--claude-4.6-sonnet`
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `e342934b-9d86-46f0-b0f4-7106b2d3bfcf`
</details>
