### PR TITLE
fix(security): ci

### DIFF
--- a/.github/actions/integration-tests/action.yml
+++ b/.github/actions/integration-tests/action.yml
@@ -54,12 +54,12 @@ runs:
           fi
         done
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
     - name: Use Node.js ${{ inputs.NODE_VERSION }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: ${{ inputs.NODE_VERSION }}
 

--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -13,10 +13,6 @@ jobs:
     name: Check Changelog Action
     runs-on: ubuntu-latest
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
       - uses: tarides/changelog-check-action@0189fc7eedec3ef3e9648c713908f6f2a6e99057 # v3
         with:
           changelog: CHANGELOG.md

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -12,10 +12,6 @@ jobs:
   label_issues:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
       - run: gh issue edit "$NUMBER" --add-label "$LABELS"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -17,10 +17,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       - run: npm i

--- a/.github/workflows/prevent-issue-labeling.yml
+++ b/.github/workflows/prevent-issue-labeling.yml
@@ -11,10 +11,6 @@ jobs:
   remove_new_label:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
       - name: Remove "New" label if applied by non-bot user
         if: >
           contains(github.event.issue.labels.*.name, 'New') &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,6 @@ jobs:
         node-version: [20.x, 22.x]
         cds-version: [latest]
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -35,10 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - run: npm i
       - name: get-version
         id: package-version
-        uses: martinbeentjes/npm-get-version-action@v1.2.3
+        uses: martinbeentjes/npm-get-version-action@7aa1d82604bb2dbe377a64ca35e692e6fe333c9c # v1.2.3
       - name: Parse changelog
         id: parse-changelog
         uses: schwma/parse-changelog-action@69a9f9ab4cf2f2e736108ab41396fc3c55f65e40 # v1.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request:
+  pull_request_target:
     branches: [main]
     types: [reopened, synchronize, opened]
 
@@ -12,9 +12,20 @@ permissions:
   contents: read
 
 jobs:
+  requires-approval:
+    runs-on: ubuntu-latest
+    name: Waiting for PR approval as this workflow runs on pull_request_target
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.owner.login != 'cap-js'
+    environment: pr-approval
+    steps:
+      - name: Approval Step
+        run: echo "This job has been approved!"
+
   test:
     name: Tests
     runs-on: ubuntu-latest
+    needs: requires-approval
+    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     timeout-minutes: 3
     strategy:
       fail-fast: false
@@ -37,10 +48,12 @@ jobs:
       - run: npm i
       - run: cd test/bookshop && npm i
       - run: npm run test
+
   integration-tests:
     runs-on: ubuntu-latest
+    needs: requires-approval
+    if: always() && (needs.requires-approval.result == 'success' || needs.requires-approval.result == 'skipped')
     name: Integration Tests
-    environment: CI
     strategy:
       fail-fast: false
       matrix:
@@ -56,7 +69,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Integration tests
-        uses: ./.github/actions/integration-tests
+        uses: cap-js/print/.github/actions/integration-tests@main
         with:
           CF_API: ${{ secrets.CF_API }}
           CF_USERNAME: ${{ secrets.CF_USERNAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,6 @@ jobs:
         node-version: [20.x, 22.x]
         cds-version: [latest]
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -60,14 +56,6 @@ jobs:
         node-version: [20.x, 22.x]
         cds-version: [latest]
     steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
-        with:
-          egress-policy: audit
-      - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Integration tests
         uses: cap-js/print/.github/actions/integration-tests@main
         with:


### PR DESCRIPTION
# Fix CI Security: Pin Action Versions and Harden Workflow Triggers

### Bug Fix / Security

🔒 Improved CI pipeline security by pinning GitHub Actions to specific commit SHAs, removing the `step-security/harden-runner` step, switching the test workflow to `pull_request_target` with an explicit approval gate for external contributors, and fixing the integration tests action reference.

### Changes

* `.github/workflows/test.yml`:
  - Changed trigger from `pull_request` to `pull_request_target` to allow workflows to access secrets for external PRs.
  - Added a `requires-approval` job gating execution for PRs from forks outside the `cap-js` org, using a `pr-approval` environment.
  - Both `test` and `integration-tests` jobs now depend on `requires-approval` and only run when it succeeds or is skipped.
  - Removed `step-security/harden-runner` steps from all jobs.
  - Removed redundant `checkout` step from `integration-tests` job.
  - Removed hardcoded `environment: CI` from `integration-tests` job.
  - Updated `integration-tests` to reference the reusable action as `cap-js/print/.github/actions/integration-tests@main` instead of the local path.

* `.github/actions/integration-tests/action.yml`:
  - Pinned `actions/checkout` to commit SHA `93cb6efe...` (v5).
  - Pinned `actions/setup-node` to commit SHA `49933ea5...` (v4).

* `.github/workflows/check-changelog.yml`: Removed `step-security/harden-runner` step.

* `.github/workflows/issue.yml`: Removed `step-security/harden-runner` step.

* `.github/workflows/lint-prettier.yml`: Removed `step-security/harden-runner` step.

* `.github/workflows/prevent-issue-labeling.yml`: Removed `step-security/harden-runner` step.

* `.github/workflows/release.yml`:
  - Removed `step-security/harden-runner` steps from both `test` and `publish-npm` jobs.
  - Pinned `martinbeentjes/npm-get-version-action` to commit SHA `7aa1d826...` (v1.2.3).

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.42`

- Event Trigger: `pull_request.opened`
- LLM: `anthropic--claude-4.6-sonnet`
- File Content Strategy: Full file content
- Output Template: [Default Template](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- Correlation ID: `a4b7bef1-0d98-4edf-b991-573eb9467905`
- Summary Prompt: [Default Prompt](https://github.tools.sap/intelligent-insights/i2-pull-request/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
</details>
